### PR TITLE
Fix token handling security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ uvx discord-voicebot --token=<your_discord_token_here>
 sudo useradd -r -m -s /usr/sbin/nologin voicebot
 
 # 4.3  Copy the systemd unit file
+
 sudo cp $(python -m importlib.resources files discord-voicebot.data discord_voicebot@.service) \
          /etc/systemd/system
-sudo systemctl enable --now discord_voicebot@<your_discord_token_here>
+# 4.4 Create an environment file with your token
+sudo install -Dm600 /dev/null /etc/discord-voicebot/bot.env
+echo "DISCORD_TOKEN=<your_discord_token_here>" | sudo tee /etc/discord-voicebot/bot.env > /dev/null
 
-# 4.4  Fire it up
+# 4.5 Fire it up (using "bot" as the instance name)
 sudo systemctl daemon-reload
-sudo systemctl enable --now discord_voicebot
-sudo journalctl -u discord_voicebot -f   # live logs
+sudo systemctl enable --now discord_voicebot@bot
+sudo journalctl -u discord_voicebot@bot -f   # live logs
 ```
 
 ---
@@ -91,10 +94,8 @@ export DISCORD_TOKEN=<your_discord_token_here>
 uvx discord-voicebot
 ```
 
-### 3. Configuration Files (.env)
-Create a `.env` file with your token in one of these locations (checked in order):
-
-**Option A:** XDG config directory (recommended)
+### 3. Configuration File (.env)
+Create a `.env` file in your XDG config directory:
 ```bash
 # Create the config directory
 mkdir -p ~/.config/voicebot
@@ -103,20 +104,14 @@ mkdir -p ~/.config/voicebot
 echo "DISCORD_TOKEN=<your_discord_token_here>" > ~/.config/voicebot/.env
 ```
 
-**Option B:** Current working directory
-```bash
-# In your project directory
-echo "DISCORD_TOKEN=<your_discord_token_here>" > .env
-```
-
 > **⚠️ Security Note:** Never commit `.env` files containing tokens to version control. Add `.env` to your `.gitignore`.
 
 ### For systemd Service
-The systemd template service automatically handles token management:
+The systemd template service reads the token from an environment file:
 ```bash
-sudo systemctl enable --now discord_voicebot@<your_discord_token_here>
+sudo systemctl enable --now discord_voicebot@bot
 ```
-This passes the token via command line to the service instance.
+This expects `/etc/discord-voicebot/bot.env` to contain your token.
 
 ---
 

--- a/data/discord_voicebot@.service
+++ b/data/discord_voicebot@.service
@@ -5,8 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/uvx discord-voicebot --token=%i
-# fallback if ExecStart lacks --token
+ExecStart=/usr/local/bin/uvx discord-voicebot
 EnvironmentFile=/etc/discord-voicebot/%i.env
 Restart=on-failure
 RestartSec=10

--- a/src/discord_voicebot/util.py
+++ b/src/discord_voicebot/util.py
@@ -23,15 +23,13 @@ def find_token() -> str:
     if token := os.getenv("DISCORD_TOKEN"):
         return token
 
-    # priority 3: .env in XDG config or cwd
-    paths = [
+    # priority 3: .env in XDG config only
+    env_file = (
         pathlib.Path(os.getenv("XDG_CONFIG_HOME", "~/.config")).expanduser()
         / "voicebot"
-        / ".env",
-        pathlib.Path(".env"),
-    ]
-    for p in paths:
-        if p.exists():
-            return dotenv_values(p).get("DISCORD_TOKEN", "") or ""
+        / ".env"
+    )
+    if env_file.exists():
+        return dotenv_values(env_file).get("DISCORD_TOKEN", "") or ""
 
     raise RuntimeError("Discord token not found. See README.")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -54,11 +54,11 @@ def test_get_channel_for_message_returns_channel():
     channels = [DummyChannel(False), DummyChannel(True)]
     guild = DummyGuild(channels)
     client = DummyBot(guild)
-    assert bot_mod.get_channel_for_message(None, client, guild.id) is channels[1]
+    assert bot_mod.get_channel_for_message(client, guild.id) is channels[1]
 
 
 def test_get_channel_for_message_returns_none():
     channels = [DummyChannel(False)]
     guild = DummyGuild(channels)
     client = DummyBot(guild)
-    assert bot_mod.get_channel_for_message(None, client, guild.id) is None
+    assert bot_mod.get_channel_for_message(client, guild.id) is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,7 +30,8 @@ def test_find_token_dotenv_cwd(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     monkeypatch.chdir(tmp_path)
     tmp_path.joinpath(".env").write_text("DISCORD_TOKEN=file-token")
-    assert util.find_token() == "file-token"
+    with pytest.raises(RuntimeError):
+        util.find_token()
 
 
 def test_find_token_dotenv_xdg(monkeypatch, tmp_path):
@@ -41,6 +42,18 @@ def test_find_token_dotenv_xdg(monkeypatch, tmp_path):
     env_dir.joinpath(".env").write_text("DISCORD_TOKEN=xdg-token")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
     monkeypatch.chdir(tmp_path)
+    assert util.find_token() == "xdg-token"
+
+
+def test_find_token_xdg_overrides_cwd(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    config_home = tmp_path / "config"
+    env_dir = config_home / "voicebot"
+    env_dir.mkdir(parents=True)
+    env_dir.joinpath(".env").write_text("DISCORD_TOKEN=xdg-token")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.chdir(tmp_path)
+    tmp_path.joinpath(".env").write_text("DISCORD_TOKEN=file-token")
     assert util.find_token() == "xdg-token"
 
 


### PR DESCRIPTION
## Summary
- restrict token lookup to `~/.config/voicebot`
- remove token flag from systemd unit
- update instructions for systemd and env files
- fix token loading tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686accb5351c832eb6795de612bb05bf