### PR TITLE
Fix CLI token parsing

### DIFF
--- a/src/discord_voicebot/bot.py
+++ b/src/discord_voicebot/bot.py
@@ -1,4 +1,6 @@
+import argparse
 import logging
+import os
 import random
 
 import discord
@@ -71,5 +73,12 @@ class VoiceBot:
         self.bot.run(self.token)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the Discord VoiceBot")
+    parser.add_argument("--token", help="Discord bot token")
+    args = parser.parse_args(argv)
+
+    if args.token:
+        os.environ["_VOICEBOT_TOKEN_CLI"] = args.token
+
     VoiceBot().run()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5,6 +5,18 @@ import discord
 from discord_voicebot import bot as bot_mod
 
 
+def test_main_cli_token_sets_env(monkeypatch):
+    monkeypatch.delenv("_VOICEBOT_TOKEN_CLI", raising=False)
+    captured = {}
+
+    def fake_run(self):
+        captured["token"] = self.token
+
+    monkeypatch.setattr(bot_mod.VoiceBot, "run", fake_run)
+    bot_mod.main(["--token", "cli-token"])
+    assert captured["token"] == "cli-token"
+
+
 def test_is_member_joined_positive():
     before = Mock(spec=discord.VoiceState)
     before.channel = None


### PR DESCRIPTION
## Summary
- parse `--token` CLI argument in `bot.py`
- test CLI token handling

## Testing
- `ruff check .`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aff2d3cb0832e8015574c00f51d2e