### PR TITLE
Add env-based health check settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ This expects `/etc/discord-voicebot/bot.env` to contain your token.
 ## Optional Health Checks
 
 Pass a URL to `--ping-url` to periodically ping a health check service. The
-interval in seconds can be adjusted with `--ping-interval` (defaults to 300):
+interval in seconds can be adjusted with `--ping-interval` (defaults to 300).
+You can also set the environment variables `VOICEBOT_PING_URL` and
+`VOICEBOT_PING_INTERVAL` (or define them in the config `.env` file) instead of
+command line options:
 
 ```bash
 uvx discord-voicebot --ping-url=https://hc-ping.com/YOUR-UUID --ping-interval=600

--- a/src/discord_voicebot/bot.py
+++ b/src/discord_voicebot/bot.py
@@ -40,10 +40,16 @@ def get_channel_for_message(bot_client, guild_id):
 
 
 class VoiceBot:
-    def __init__(self, ping_url: str | None = None, ping_interval: int = 300) -> None:
+    def __init__(
+        self,
+        ping_url: str | None = None,
+        ping_interval: int | None = None,
+    ) -> None:
         self.token = util.find_token()
-        self.ping_url = ping_url
-        self.ping_interval = ping_interval
+        self.ping_url = ping_url if ping_url is not None else util.find_ping_url()
+        self.ping_interval = (
+            ping_interval if ping_interval is not None else util.find_ping_interval()
+        )
         self.bot = commands.Bot(command_prefix="!", intents=util.intents())
 
         self.bot.event(self.on_ready)
@@ -100,12 +106,16 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--ping-interval",
         type=int,
-        default=300,
+        default=None,
         help="Seconds between health check pings",
     )
     args = parser.parse_args(argv)
 
     if args.token:
         os.environ["_VOICEBOT_TOKEN_CLI"] = args.token
+    if args.ping_url:
+        os.environ["_VOICEBOT_PING_URL_CLI"] = args.ping_url
+    if args.ping_interval is not None:
+        os.environ["_VOICEBOT_PING_INTERVAL_CLI"] = str(args.ping_interval)
 
     VoiceBot(ping_url=args.ping_url, ping_interval=args.ping_interval).run()

--- a/src/discord_voicebot/util.py
+++ b/src/discord_voicebot/util.py
@@ -13,23 +13,65 @@ def intents() -> discord.Intents:
     return intents
 
 
-def find_token() -> str:
-    """Locate the Discord token using several fallbacks."""
-    # priority 1: command line (exported for systemd template)
-    if token := os.getenv("_VOICEBOT_TOKEN_CLI"):
-        return token
-
-    # priority 2: plain env var
-    if token := os.getenv("DISCORD_TOKEN"):
-        return token
-
-    # priority 3: .env in XDG config only
-    env_file = (
+def _env_file() -> pathlib.Path:
+    return (
         pathlib.Path(os.getenv("XDG_CONFIG_HOME", "~/.config")).expanduser()
         / "voicebot"
         / ".env"
     )
-    if env_file.exists():
-        return dotenv_values(env_file).get("DISCORD_TOKEN", "") or ""
 
+
+def _find_env_var(cli_var: str, plain_var: str, *, cast=str, default=None):
+    if val := os.getenv(cli_var):
+        try:
+            return cast(val)
+        except Exception:
+            return default
+    if val := os.getenv(plain_var):
+        try:
+            return cast(val)
+        except Exception:
+            return default
+    env_file = _env_file()
+    if env_file.exists():
+        data = dotenv_values(env_file)
+        if val := data.get(plain_var):
+            try:
+                return cast(val)
+            except Exception:
+                return default
+    return default
+
+
+def find_token() -> str:
+    """Locate the Discord token using several fallbacks."""
+    token = _find_env_var("_VOICEBOT_TOKEN_CLI", "DISCORD_TOKEN")
+    if token:
+        return token
     raise RuntimeError("Discord token not found. See README.")
+
+
+def find_ping_url(default: str | None = None) -> str | None:
+    """Return the health check URL from env or config."""
+    return _find_env_var(
+        "_VOICEBOT_PING_URL_CLI",
+        "VOICEBOT_PING_URL",
+        default=default,
+    )
+
+
+def find_ping_interval(default: int = 300) -> int:
+    """Return the ping interval in seconds from env or config."""
+
+    def to_int(val: str) -> int:
+        try:
+            return int(val)
+        except ValueError:
+            return default
+
+    return _find_env_var(
+        "_VOICEBOT_PING_INTERVAL_CLI",
+        "VOICEBOT_PING_INTERVAL",
+        cast=to_int,
+        default=default,
+    )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -35,6 +35,26 @@ def test_main_health_args(monkeypatch):
     assert captured["interval"] == 10
 
 
+def test_main_health_env(monkeypatch):
+    for var in [
+        "_VOICEBOT_PING_URL_CLI",
+        "_VOICEBOT_PING_INTERVAL_CLI",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    captured = {}
+
+    def fake_run(self):
+        captured["url"] = self.ping_url
+        captured["interval"] = self.ping_interval
+
+    monkeypatch.setattr(bot_mod.VoiceBot, "run", fake_run)
+    monkeypatch.setenv("VOICEBOT_PING_URL", "http://env")
+    monkeypatch.setenv("VOICEBOT_PING_INTERVAL", "55")
+    bot_mod.main([])
+    assert captured["url"] == "http://env"
+    assert captured["interval"] == 55
+
+
 def test_is_member_joined_positive():
     before = Mock(spec=discord.VoiceState)
     before.channel = None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,15 @@ from discord_voicebot import util
 
 
 def _clear_env(monkeypatch):
-    for var in ["_VOICEBOT_TOKEN_CLI", "DISCORD_TOKEN", "XDG_CONFIG_HOME"]:
+    for var in [
+        "_VOICEBOT_TOKEN_CLI",
+        "DISCORD_TOKEN",
+        "_VOICEBOT_PING_URL_CLI",
+        "VOICEBOT_PING_URL",
+        "_VOICEBOT_PING_INTERVAL_CLI",
+        "VOICEBOT_PING_INTERVAL",
+        "XDG_CONFIG_HOME",
+    ]:
         monkeypatch.delenv(var, raising=False)
 
 
@@ -62,3 +70,27 @@ def test_find_token_not_found(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     with pytest.raises(RuntimeError):
         util.find_token()
+
+
+def test_find_ping_url_from_cli(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("_VOICEBOT_PING_URL_CLI", "http://cli")
+    assert util.find_ping_url() == "http://cli"
+
+
+def test_find_ping_url_from_env(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("VOICEBOT_PING_URL", "http://env")
+    assert util.find_ping_url() == "http://env"
+
+
+def test_find_ping_interval_from_cli(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("_VOICEBOT_PING_INTERVAL_CLI", "42")
+    assert util.find_ping_interval() == 42
+
+
+def test_find_ping_interval_from_env(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("VOICEBOT_PING_INTERVAL", "99")
+    assert util.find_ping_interval() == 99


### PR DESCRIPTION
## Summary
- pull health check URL and interval from env or config
- respect CLI arguments for ping settings
- document new environment variables
- test ping settings environment handling

## Testing
- `uv run -- ruff check tests/test_bot.py tests/test_util.py src/discord_voicebot`
- `uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b27b93da0832eaab6b577880317f1